### PR TITLE
Support for Assist tts.speak service

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ notify:
 
 Please note that the `tts_service` parameter, must match the `service_name` defined in the TTS integration.
 
+You can use the Assist `tts.speak` service, but it is required to specify the tts engine entity_id.  For example, `entity_id: tts.piper` 
+
 ### CONFIGURATION VARIABLES & SERVICE OPTIONS
 ___
 
@@ -54,6 +56,9 @@ The entity_id of a LMS media_player (single or list for service queue)
 #### **device_group**: `string` | REQUIRED | CONFIG | (optional) | SERVICE QUEUE & SERVICE NOTIFY
 Specify which entity_id to track. Messages are not played when state != `home`
 Can be any entities/groups when it has a `home` state 
+
+#### **entity_id**: `string` | (optional) | CONFIG
+The entity_id of the TTS engine (for TTS service "tts.speak" only)
 
 #### **volume**: `float` (optional) | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
 Default volume to play the alert_sound and message

--- a/custom_components/lms_tts_notify/__init__.py
+++ b/custom_components/lms_tts_notify/__init__.py
@@ -394,6 +394,7 @@ class QueueListener(Thread):
         self._volume = config.get(CONF_VOLUME)
         self._pause = config.get(CONF_PAUSE)
         self._media_player = config[CONF_MEDIA_PLAYER]
+        self._tts_engine = config.get(ATTR_ENTITY_ID)
         self._config = config
         self._sync_group = []
         _, self._tts_service = split_entity_id(config[CONF_TTS_SERVICE])
@@ -516,7 +517,18 @@ class QueueListener(Thread):
 
             # Play message
             if self._message:
-                service_data = {'entity_id': self._media_player, 'message': self._message}
+                if 'speak' in self._tts_service:
+                    service_data = {
+                        'entity_id': self._tts_engine,
+                        'media_player_entity_id': self._media_player,
+                        'message': self._message,
+                    }
+                else:
+                    service_data = {
+                        ATTR_ENTITY_ID: self._media_player,
+                        'message': self._message,
+                    }
+
                 self._hass.services.call('tts', self._tts_service, service_data)
                 time.sleep(self._pause)
             self.wait_on_idle()

--- a/custom_components/lms_tts_notify/manifest.json
+++ b/custom_components/lms_tts_notify/manifest.json
@@ -7,5 +7,5 @@
     "issue_tracker": "https://github.com/floris-b/lms_tts_notify/issues",
     "after_dependencies": ["media_player", "squuezebox"],
     "iot_class": "local_push",
-    "version": "0.3.14"
+    "version": "0.3.15"
   }

--- a/custom_components/lms_tts_notify/notify.py
+++ b/custom_components/lms_tts_notify/notify.py
@@ -13,16 +13,18 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.components.notify import ATTR_MESSAGE
 
-DOMAIN = "lms_tts_notify"
-ATTR_LANGUAGE = "language"
+from . import (
+    DOMAIN,
+    CONF_MEDIA_PLAYER,
+    CONF_TTS_SERVICE,
+    CONF_REPEAT,
+    CONF_VOLUME,
+    CONF_ALERT_SOUND,
+    CONF_DEVICE_GROUP,
+    CONF_PAUSE,
+)
 
-CONF_MEDIA_PLAYER = "media_player"
-CONF_TTS_SERVICE = "tts_service"
-CONF_REPEAT = "repeat"
-CONF_VOLUME = "volume"
-CONF_ALERT_SOUND = "alert_sound"
-CONF_DEVICE_GROUP = "device_group"
-CONF_PAUSE = "pause"
+ATTR_LANGUAGE = "language"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +34,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_TTS_SERVICE): cv.entity_id,
         vol.Required(CONF_MEDIA_PLAYER): cv.entity_id,
         vol.Required(CONF_DEVICE_GROUP): cv.entity_id,
+        vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
         vol.Optional(ATTR_LANGUAGE): cv.string,
         vol.Optional(CONF_REPEAT, default=1): cv.positive_int,
         vol.Optional(CONF_ALERT_SOUND, default=""): cv.string,

--- a/info.md
+++ b/info.md
@@ -39,6 +39,8 @@ notify:
 
 Please note that the `tts_service` parameter, must match the `service_name` defined in the TTS integration.
 
+You can use the Assist `tts.speak` service, but it is required to specify the tts engine entity_id.  For example, `entity_id: tts.piper`
+
 ### CONFIGURATION VARIABLES & SERVICE OPTIONS
 ___
 
@@ -54,6 +56,9 @@ The entity_id of a LMS media_player (single or list for service queue)
 #### **device_group**: `string` | REQUIRED | CONFIG | (optional) | SERVICE QUEUE & SERVICE NOTIFY
 Specify which entity_id to track. Messages are not played when state != `home`
 Can be any entities/groups when it has a `home` state 
+
+#### **entity_id**: `string` | (optional) | CONFIG
+The entity_id of the TTS engine (for TTS service "tts.speak" only)
 
 #### **volume**: `float` (optional) | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
 Default volume to play the alert_sound and message


### PR DESCRIPTION
As discussed in #15 , the new TTS platform used in Assist did not work with the current code, as it requires a new format for the service call which includes a TTS engine entity_id.

This PR provides basic support with minimal changes to the existing code.   