### PR TITLE
Add support for ChimeTTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ Default value to repeat the message
 #### **force_play**: `boolean` | SERVICE QUEUE & SERVICE NOTIFY
 Skip check `device_group` state is `home` 
 
+#### **chimetts_chime_path**: `string` | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
+A preset or custom audio file to be played before TTS audio. [ChimeTTS](https://github.com/nimroddolev/chime_tts) option.
+
+#### **chimetts_end_chime_path**: `string` | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
+A preset or custom audio file to be played after TTS audio. [ChimeTTS](https://github.com/nimroddolev/chime_tts) option.
+
+#### **chimetts_offset**: `float` | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
+Delay between audio segments when value > 0, or overlays audio segments when value < 0. [ChimeTTS](https://github.com/nimroddolev/chime_tts) option.
+
+#### **chimetts_final_delay**: `float` | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
+Delay (in milliseconds) added to the end of the audio. [ChimeTTS](https://github.com/nimroddolev/chime_tts) option.
+
+#### **chimetts_tts_speed**: `float` | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
+Speed of the TTS audio. [ChimeTTS](https://github.com/nimroddolev/chime_tts) option.
+
+#### **chimetts_tts_pitch**: `float` | CONFIG & SERVICE QUEUE & SERVICE NOTIFY
+TTS pitch in semitones. [ChimeTTS](https://github.com/nimroddolev/chime_tts) option.
+
 ### SERVICE QUEUE
 ---
 A service `lms_tts_notify.queue` is also added (besides the notify service for each player) for easy use with the automations gui

--- a/custom_components/lms_tts_notify/manifest.json
+++ b/custom_components/lms_tts_notify/manifest.json
@@ -7,5 +7,5 @@
     "issue_tracker": "https://github.com/floris-b/lms_tts_notify/issues",
     "after_dependencies": ["media_player", "squuezebox"],
     "iot_class": "local_push",
-    "version": "0.3.15"
+    "version": "0.3.16"
   }

--- a/custom_components/lms_tts_notify/services.yaml
+++ b/custom_components/lms_tts_notify/services.yaml
@@ -49,3 +49,200 @@ queue:
       description: Specify which group/enity to track and only play when home
       selector:
         entity:
+
+    chimetts_chime_path:
+      name: "Chime TTS: Chime Path"
+      description: "A preset or custom audio file to be played before TTS audio"
+      example: "custom_components/chime_tts/mp3s/bells.mp3"
+      required: false
+      selector:
+        select:
+          translation_key: "chime_paths"
+          multiple: false
+          custom_value: true
+          mode: dropdown
+          options:
+            - label: "Ba-Dum Tss!"
+              value: "ba_dum_tss"
+            - label: "Bells"
+              value: "bells"
+            - label: "Bells 2"
+              value: "bells_2"
+            - label: "Bright"
+              value: "bright"
+            - label: "Chirp"
+              value: "chirp"
+            - label: "Choir"
+              value: "choir"
+            - label: "Chord"
+              value: "chord"
+            - label: "Classical"
+              value: "classical"
+            - label: "Crickets"
+              value: "crickets"
+            - label: "Ding Dong"
+              value: "ding_dong"
+            - label: "Drum Roll"
+              value: "drumroll"
+            - label: "Dun dun DUUUN!"
+              value: "dun_dun_dun"
+            - label: "Error"
+              value: "error"
+            - label: "Fanfare"
+              value: "fanfare"
+            - label: "Glockenspiel"
+              value: "glockenspiel"
+            - label: "Hail"
+              value: "hail"
+            - label: "Knock"
+              value: "knock"
+            - label: "Marimba"
+              value: "marimba"
+            - label: "Mario Coin"
+              value: "mario_coin"
+            - label: "Microphone Tap"
+              value: "microphone_tap"
+            - label: "Ta-da!"
+              value: "tada"
+            - label: "Toast"
+              value: "toast"
+            - label: "Twenty Four"
+              value: "twenty_four"
+            - label: "Sad Trombone"
+              value: "sad_trombone"
+            - label: "Soft"
+              value: "soft"
+            - label: "Whistle"
+              value: "whistle"
+            - label: "Custom 1"
+              value: "custom_chime_path_1"
+            - label: "Custom 2"
+              value: "custom_chime_path_2"
+            - label: "Custom 3"
+              value: "custom_chime_path_3"
+            - label: "Custom 4"
+              value: "custom_chime_path_4"
+            - label: "Custom 5"
+              value: "custom_chime_path_5"
+    chimetts_end_chime_path:
+      name: "Chime TTS: End Chime Path"
+      description: "A preset or custom audio file to be played after TTS audio"
+      example: "custom_components/chime_tts/mp3s/tada.mp3"
+      required: false
+      selector:
+        select:
+          translation_key: "chime_paths"
+          multiple: false
+          custom_value: true
+          mode: dropdown
+          options:
+            - label: "Ba-Dum Tss!"
+              value: "ba_dum_tss"
+            - label: "Bells"
+              value: "bells"
+            - label: "Bells 2"
+              value: "bells_2"
+            - label: "Bright"
+              value: "bright"
+            - label: "Chirp"
+              value: "chirp"
+            - label: "Choir"
+              value: "choir"
+            - label: "Chord"
+              value: "chord"
+            - label: "Classical"
+              value: "classical"
+            - label: "Crickets"
+              value: "crickets"
+            - label: "Ding Dong"
+              value: "ding_dong"
+            - label: "Drum Roll"
+              value: "drumroll"
+            - label: "Dun dun DUUUN!"
+              value: "dun_dun_dun"
+            - label: "Error"
+              value: "error"
+            - label: "Fanfare"
+              value: "fanfare"
+            - label: "Glockenspiel"
+              value: "glockenspiel"
+            - label: "Hail"
+              value: "hail"
+            - label: "Knock"
+              value: "knock"
+            - label: "Marimba"
+              value: "marimba"
+            - label: "Mario Coin"
+              value: "mario_coin"
+            - label: "Microphone Tap"
+              value: "microphone_tap"
+            - label: "Ta-da!"
+              value: "tada"
+            - label: "Toast"
+              value: "toast"
+            - label: "Twenty Four"
+              value: "twenty_four"
+            - label: "Sad Trombone"
+              value: "sad_trombone"
+            - label: "Soft"
+              value: "soft"
+            - label: "Whistle"
+              value: "whistle"
+            - label: "Custom 1"
+              value: "custom_chime_path_1"
+            - label: "Custom 2"
+              value: "custom_chime_path_2"
+            - label: "Custom 3"
+              value: "custom_chime_path_3"
+            - label: "Custom 4"
+              value: "custom_chime_path_4"
+            - label: "Custom 5"
+              value: "custom_chime_path_5"
+    chimetts_offset:
+      name: "Chime TTS: Offset"
+      description: "Adds a delay between audio segments when value > 0, or overlays audio segments when value < 0."
+      example: 450
+      required: false
+      selector:
+        number:
+          mode: box
+          min: -10000
+          max: 10000
+          step: 10
+          unit_of_measurement: ms
+    chimetts_final_delay:
+      name: "Chime TTS: Final Delay"
+      description: "Final delay (in milliseconds) added to the end of the audio"
+      example: 100
+      required: false
+      selector:
+        number:
+          mode: box
+          min: 0
+          max: 10000
+          step: 1
+          unit_of_measurement: ms
+    chimetts_tts_speed:
+      name: "Chime TTS: TTS Speed"
+      description: "Set the speed of the TTS audio to between 1% and 500% of the original"
+      example: 125
+      required: false
+      selector:
+        number:
+          mode: slider
+          min: 1
+          max: 500
+          step: 5
+          unit_of_measurement: '%'
+    chimetts_tts_pitch:
+      name: "Chime TTS: TTS Pitch"
+      description: "Change the the TTS pitch in semitones. Negative values for lower, positive for higher"
+      example: 3
+      required: false
+      selector:
+        number:
+          mode: slider
+          min: -100
+          max: 100
+          step: 1
+          unit_of_measurement: 'semitones'


### PR DESCRIPTION
[ChimeTTS](https://github.com/nimroddolev/chime_tts) is another TTS wrapper that adds the ability to modify the audio sent to the media players. For example, similar to `alert_sound`, a pre-message sound can be added. In addition, it can also do fading, post-message sounds, etc. 

In my setting, only one of my media players (PiCorePlayer) was able to play from the already implemented TTS systems. The other media players ([squeezelite-esp32](https://github.com/sle118/squeezelite-esp32)) simply refused to do it. The only way to get all of them playing was to use ChimeTTS.

In this PR, I added the option to use ChimeTTS as another alternative TTS provider. It is tested for my setup.

## Configuration examples

`configuration.yaml` example:

```yaml
notify:
  - platform: lms_tts_notify
    name: bose_livingroom
    tts_service: chime_tts.say
    entity_id: tts.piper
    media_player: media_player.bose_livingroom
    device_group: person.xyz
    force_play: true
    volume: 0.4
    chimetts_chime_path: glockenspiel
    chimetts_end_chime_path: marimba
    chimetts_tts_pitch: 3
```

Service call to service queue:
```yaml
service: lms_tts_notify.queue
metadata: {}
data:
  message: This is a message
  volume: 0.6
  force_play: true
  device_group: person.xyz
  entity_id: media_player.bose_livingroom
  chimetts_chime_path: bells
  chimetts_end_chime_path: ba_dum_tss
  chimetts_offset: 250
  chimetts_final_delay: 50
  chimetts_tts_speed: 116
  chimetts_tts_pitch: 1
```

Service call to service notify:
```yaml
service: notify.bose_livingroom
data:
  message: This is a message
  data:
    chimetts_chime_path: bells
    chimetts_end_chime_path: ba_dum_tss
    chimetts_offset: 250
    chimetts_final_delay: 50
    chimetts_tts_speed: 116
    chimetts_tts_pitch: 1
```

## Known issues
### Unsetting defaults
To unset defaults from `configuration.yaml` the key needs to be actively set in the service call.

For example to unset `chimetts_chime_path: bells` it needs to be set to e.g. `chimetts_chime_path: custom_chime_path_1`, which is empty (at least in my case).